### PR TITLE
Get any user profile scripts ("~/.bash_profile", etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,9 @@ Below are the Venator modules and the data each module contains. Once the script
 * user
 * bash_commands
 * hostname
+
+`shell_startup`: 
+* user
+* hostname
+* shell_startup_filename
+* shell_startup_data


### PR DESCRIPTION
Get any user profile scripts. These scripts are run every time a shell is launched by a user.

A malicious actor can add a backdoor script into these files, then either wait for the
user to logon, or launch a shell using an innocuous cronjob, etc.